### PR TITLE
feat: add unsupported kraken events endpoint

### DIFF
--- a/src/API/Unsupported/ChannelEvent.ts
+++ b/src/API/Unsupported/ChannelEvent.ts
@@ -1,0 +1,54 @@
+import Channel, { ChannelData } from '../Channel/';
+import Twitch from '../../';
+import { NonEnumerable } from '../../Toolkit/Decorators';
+
+export interface ChannelEventData {
+	_id: string;
+	start_time: string;
+	end_time: string;
+	time_zone_id: string;
+	title: string;
+	description: string;
+	cover_image_url: string;
+	language: string;
+	channel: ChannelData;
+	// game: GameData;
+}
+
+export default class ChannelEvent {
+	@NonEnumerable _client: Twitch;
+
+	constructor(private _data: ChannelEventData, client: Twitch) {
+		this._client = client;
+	}
+
+	get channel() {
+		return new Channel(this._data.channel, this._client);
+	}
+
+	get id() {
+		return this._data._id;
+	}
+
+	get startTime() {
+		return Date.parse(this._data.start_time);
+	}
+
+	get endTime() {
+		return Date.parse(this._data.end_time);
+	}
+
+	get title() {
+		return this._data.title;
+	}
+
+	get description() {
+		return this._data.description;
+	}
+
+	buildCoverImageUrl(width: number, height: number) {
+		return this._data.cover_image_url
+			.replace("{width}", width.toString())
+			.replace("{height}", height.toString());
+	}
+}

--- a/src/API/Unsupported/UnsupportedAPI.ts
+++ b/src/API/Unsupported/UnsupportedAPI.ts
@@ -2,6 +2,8 @@ import { Cacheable, Cached } from '../../Toolkit/Decorators';
 import BaseAPI from '../BaseAPI';
 import Channel from '../Channel';
 import ChattersList, { ChattersListData } from './ChattersList';
+import UserTools, { UserIdResolvable } from '../../Toolkit/UserTools';
+import ChannelEvent, { ChannelEventData } from './ChannelEvent';
 
 @Cacheable
 export default class UnsupportedAPI extends BaseAPI {
@@ -13,5 +15,12 @@ export default class UnsupportedAPI extends BaseAPI {
 
 		const data: ChattersListData = await this._client.apiCall({url: `https://tmi.twitch.tv/group/user/${channel}/chatters`, type: 'custom'});
 		return new ChattersList(data);
+	}
+
+	@Cached(60)
+	async getEvents(channel: UserIdResolvable) {
+		const channelId = UserTools.getUserId(channel);
+		const data = await this._client.apiCall({url: `channels/${channelId}/events`});
+		return data.events.map((event: ChannelEventData) => new ChannelEvent(event, this._client));
 	}
 }


### PR DESCRIPTION
As is tradition this is completely untested. And yes, I don't care if that endpoint has pagination or anything, it probably has, since it has a `_total` but I've never seen a channel that had enough events queued to require this...