### PR TITLE
Add event handler for no_permission event

### DIFF
--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -348,7 +348,7 @@ export default class ChatClient extends IRCClient {
 
 	/**
 	 * @eventListener
-	 * @param target The channel that a command without sufficient permissions was executed on
+	 * @param channel The channel that a command without sufficient permissions was executed on
 	 * @maram message The message response from the server
 	 */
 	onNoPermission: (handler: (channel: string, message: string) => void) => Listener = this.registerEvent();

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -348,10 +348,9 @@ export default class ChatClient extends IRCClient {
 
 	/**
 	 * @eventListener
-	 * @param targetThe channel that a command without sufficient permissions was executed on
-	 * @maram message The message response from the twitch chat server
+	 * @param target The channel that a command without sufficient permissions was executed on
+	 * @maram message The message response from the server
 	 */
-
 	onNoPermission: (handler: (channel: string, message: string) => void) => Listener = this.registerEvent();
 
 	// override for specific class

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -346,6 +346,14 @@ export default class ChatClient extends IRCClient {
 	 */
 	onWhisper: (handler: (user: string, message: string, msg: Whisper) => void) => Listener = this.registerEvent();
 
+	/**
+	 * @eventListener
+	 * @param targetThe channel that a command without sufficient permissions was executed on
+	 * @maram message The message response from the twitch chat server
+	 */
+
+	onNoPermission: (handler: (channel: string, message: string) => void) => Listener = this.registerEvent();
+
 	// override for specific class
 	/**
 	 * Fires when a user sends a message to a channel.
@@ -921,6 +929,11 @@ export default class ChatClient extends IRCClient {
 				}
 
 				case 'unrecognized_cmd': {
+					break;
+				}
+
+				case 'no_permission': {
+					this.emit(this.onNoPermission, channel, message);
 					break;
 				}
 


### PR DESCRIPTION
In the application I've been building, I'm wanting to know when I don't have permissions on a channel that I attempt to host.

This PR adds an event listener for the no_permission NOTICE that Twitch responds with when you attempt to execute a command (such as /host) on a channel that you do not have permission to execute it on.

There's not a lot of data available in the response from Twitch, just the channel that you attempted to execute a command on without permissions.  