### PR TITLE
Add support for subscription webhooks

### DIFF
--- a/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
+++ b/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
@@ -1,0 +1,22 @@
+import Subscription from './Subscription';
+import { HelixResponse } from 'twitch';
+import WebHookListener from '../WebHookListener';
+import HelixSubscriptionEvent, { HelixSubscriptionEventData } from 'twitch/lib/API/Helix/Subscriptions/HelixSubscriptionEvent';
+
+export default class SubscriptionsToUserSubscription extends Subscription<HelixSubscriptionEvent> {
+  constructor(private readonly _userId: string, handler: (data: HelixSubscriptionEvent) => void, client: WebHookListener) {
+    super(handler, client);
+  }
+
+  transformData(response: HelixResponse<HelixSubscriptionEventData>) {
+    return new HelixSubscriptionEvent(response.data[0], this._client._twitchClient);
+  }
+
+  protected async _subscribe() {
+		return this._client._twitchClient.helix.webHooks.subscribeToUserSubscriptionEvents(this._userId, this._options);
+	}
+
+	protected async _unsubscribe() {
+		return this._client._twitchClient.helix.webHooks.unsubscribeFromUserSubscriptionEvents(this._userId, this._options);
+	}
+}

--- a/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
+++ b/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
@@ -1,18 +1,22 @@
 import Subscription from './Subscription';
-import { HelixResponse } from 'twitch';
+import { HelixResponse, HelixSubscriptionEvent } from 'twitch';
 import WebHookListener from '../WebHookListener';
-import HelixSubscriptionEvent, { HelixSubscriptionEventData } from 'twitch/lib/API/Helix/Subscriptions/HelixSubscriptionEvent';
+import { HelixSubscriptionEventData } from 'twitch/lib/API/Helix/Subscriptions/HelixSubscriptionEvent';
 
 export default class SubscriptionEventSubscription extends Subscription<HelixSubscriptionEvent> {
-  constructor(private readonly _userId: string, handler: (data: HelixSubscriptionEvent) => void, client: WebHookListener) {
-    super(handler, client);
-  }
+	constructor(
+		private readonly _userId: string,
+		handler: (data: HelixSubscriptionEvent) => void,
+		client: WebHookListener
+	) {
+		super(handler, client);
+	}
 
-  transformData(response: HelixResponse<HelixSubscriptionEventData>) {
-    return new HelixSubscriptionEvent(response.data[0], this._client._twitchClient);
-  }
+	transformData(response: HelixResponse<HelixSubscriptionEventData>) {
+		return new HelixSubscriptionEvent(response.data[0], this._client._twitchClient);
+	}
 
-  protected async _subscribe() {
+	protected async _subscribe() {
 		return this._client._twitchClient.helix.webHooks.subscribeToSubscriptionEvents(this._userId, this._options);
 	}
 

--- a/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
+++ b/packages/twitch-webhooks/src/Subscriptions/SubscriptionEventSubscription.ts
@@ -3,7 +3,7 @@ import { HelixResponse } from 'twitch';
 import WebHookListener from '../WebHookListener';
 import HelixSubscriptionEvent, { HelixSubscriptionEventData } from 'twitch/lib/API/Helix/Subscriptions/HelixSubscriptionEvent';
 
-export default class SubscriptionsToUserSubscription extends Subscription<HelixSubscriptionEvent> {
+export default class SubscriptionEventSubscription extends Subscription<HelixSubscriptionEvent> {
   constructor(private readonly _userId: string, handler: (data: HelixSubscriptionEvent) => void, client: WebHookListener) {
     super(handler, client);
   }
@@ -13,10 +13,10 @@ export default class SubscriptionsToUserSubscription extends Subscription<HelixS
   }
 
   protected async _subscribe() {
-		return this._client._twitchClient.helix.webHooks.subscribeToUserSubscriptionEvents(this._userId, this._options);
+		return this._client._twitchClient.helix.webHooks.subscribeToSubscriptionEvents(this._userId, this._options);
 	}
 
 	protected async _unsubscribe() {
-		return this._client._twitchClient.helix.webHooks.unsubscribeFromUserSubscriptionEvents(this._userId, this._options);
+		return this._client._twitchClient.helix.webHooks.unsubscribeFromSubscriptionEvents(this._userId, this._options);
 	}
 }

--- a/packages/twitch-webhooks/src/WebHookListener.ts
+++ b/packages/twitch-webhooks/src/WebHookListener.ts
@@ -5,7 +5,14 @@ import { PolkaRequest, PolkaResponse } from 'polka';
 // eslint-disable-next-line no-duplicate-imports
 import * as polka from 'polka';
 import * as https from 'https';
-import TwitchClient, { extractUserId, HelixFollow, HelixStream, HelixUser, UserIdResolvable, HelixSubscriptionEvent } from 'twitch';
+import TwitchClient, {
+	extractUserId,
+	HelixFollow,
+	HelixStream,
+	HelixUser,
+	UserIdResolvable,
+	HelixSubscriptionEvent
+} from 'twitch';
 import * as getRawBody from 'raw-body';
 
 import Subscription from './Subscriptions/Subscription';
@@ -168,7 +175,10 @@ export default class WebHookListener {
 		return subscription;
 	}
 
-	async subscribeToSubscriptionEvents(user: UserIdResolvable, handler: (subscription: HelixSubscriptionEvent) => void) {
+	async subscribeToSubscriptionEvents(
+		user: UserIdResolvable,
+		handler: (subscription: HelixSubscriptionEvent) => void
+	) {
 		const userId = extractUserId(user);
 
 		const subscription = new SubscriptionEventSubscription(userId, handler, this);

--- a/packages/twitch-webhooks/src/WebHookListener.ts
+++ b/packages/twitch-webhooks/src/WebHookListener.ts
@@ -5,7 +5,7 @@ import { PolkaRequest, PolkaResponse } from 'polka';
 // eslint-disable-next-line no-duplicate-imports
 import * as polka from 'polka';
 import * as https from 'https';
-import TwitchClient, { extractUserId, HelixFollow, HelixStream, HelixUser, UserIdResolvable } from 'twitch';
+import TwitchClient, { extractUserId, HelixFollow, HelixStream, HelixUser, UserIdResolvable, HelixSubscriptionEvent } from 'twitch';
 import * as getRawBody from 'raw-body';
 
 import Subscription from './Subscriptions/Subscription';
@@ -13,6 +13,7 @@ import UserChangeSubscription from './Subscriptions/UserChangeSubscription';
 import FollowsToUserSubscription from './Subscriptions/FollowsToUserSubscription';
 import FollowsFromUserSubscription from './Subscriptions/FollowsFromUserSubscription';
 import StreamChangeSubscription from './Subscriptions/StreamChangeSubscription';
+import SubscriptionEventSubscription from './Subscriptions/SubscriptionEventSubscription';
 
 interface WebHookListenerCertificateConfig {
 	key: string;
@@ -161,6 +162,16 @@ export default class WebHookListener {
 		const userId = extractUserId(user);
 
 		const subscription = new StreamChangeSubscription(userId, handler, this);
+		await subscription.start();
+		this._subscriptions.set(subscription.id!, subscription);
+
+		return subscription;
+	}
+
+	async subscribeToSubscriptionEvents(user: UserIdResolvable, handler: (subscription: HelixSubscriptionEvent) => void) {
+		const userId = extractUserId(user);
+
+		const subscription = new SubscriptionEventSubscription(userId, handler, this);
 		await subscription.start();
 		this._subscriptions.set(subscription.id!, subscription);
 

--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscription.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscription.ts
@@ -10,6 +10,7 @@ export interface HelixSubscriptionData {
 	tier: string;
 	user_id: string;
 	user_name: string;
+	message?: string;
 }
 
 /**

--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
@@ -1,0 +1,52 @@
+import HelixSubscription, { HelixSubscriptionData } from './HelixSubscription';
+import TwitchClient from '../../../TwitchClient';
+
+export enum HelixSubscriptionEventType {
+  Subscribe = "subscriptions.subscribe",
+  Unsubscribe = "subscriptions.unsubscribe",
+  Notification = "subscriptions.notification"
+}
+
+/** @private */
+export interface HelixSubscriptionEventData {
+	id: string,
+  event_type: HelixSubscriptionEventType,
+  event_timestamp: string,
+  version: string,
+  event_data: HelixSubscriptionData
+}
+
+export default class HelixSubscriptionEvent extends HelixSubscription {
+  /** @private */
+  constructor(private readonly _event_data: HelixSubscriptionEventData, client: TwitchClient) {
+    super(_event_data.event_data, client);
+  }
+
+  /**
+	 * The unique ID of the subscription event.
+	 */
+  get eventId() {
+    return this._event_data.id;
+  }
+
+  /**
+	 * The type of the subscription event.
+	 */
+  get eventType() {
+    return this._event_data.event_type;
+  }
+
+  /**
+	 * The date of the subscription event.
+	 */
+  get eventDate() {
+    return new Date(this._event_data.event_timestamp);
+  }
+
+  /**
+	 * The version of the subscription event.
+	 */
+  get eventVersion() {
+    return this._event_data.version;
+  }
+}

--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
@@ -2,55 +2,55 @@ import HelixSubscription, { HelixSubscriptionData } from './HelixSubscription';
 import TwitchClient from '../../../TwitchClient';
 
 export enum HelixSubscriptionEventType {
-  Subscribe = "subscriptions.subscribe",
-  Unsubscribe = "subscriptions.unsubscribe",
-  Notification = "subscriptions.notification"
+	Subscribe = 'subscriptions.subscribe',
+	Unsubscribe = 'subscriptions.unsubscribe',
+	Notification = 'subscriptions.notification'
 }
 
 /** @private */
 export interface HelixSubscriptionEventData {
-	id: string,
-  event_type: HelixSubscriptionEventType,
-  event_timestamp: string,
-  version: string,
-  event_data: HelixSubscriptionData
+	id: string;
+	event_type: HelixSubscriptionEventType;
+	event_timestamp: string;
+	version: string;
+	event_data: HelixSubscriptionData;
 }
 
 export default class HelixSubscriptionEvent extends HelixSubscription {
-  /** @private */
-  constructor(private readonly _event_data: HelixSubscriptionEventData, client: TwitchClient) {
-    super(_event_data.event_data, client);
-  }
+	/** @private */
+	constructor(private readonly _eventData: HelixSubscriptionEventData, client: TwitchClient) {
+		super(_eventData.event_data, client);
+	}
 
-  /**
+	/**
 	 * The unique ID of the subscription event.
 	 */
-  get eventId() {
-    return this._event_data.id;
-  }
+	get eventId() {
+		return this._eventData.id;
+	}
 
-  /**
+	/**
 	 * The type of the subscription event.
 	 */
-  get eventType() {
-    return this._event_data.event_type;
-  }
+	get eventType() {
+		return this._eventData.event_type;
+	}
 
-  /**
+	/**
 	 * The date of the subscription event.
 	 */
-  get eventDate() {
-    return new Date(this._event_data.event_timestamp);
-  }
+	get eventDate() {
+		return new Date(this._eventData.event_timestamp);
+	}
 
-  /**
+	/**
 	 * The version of the subscription event.
 	 */
-  get eventVersion() {
-    return this._event_data.version;
-  }
+	get eventVersion() {
+		return this._eventData.version;
+	}
 
-  get eventMessage() {
-    return this._event_data.event_data.message || null;
-  }
+	get eventMessage() {
+		return this._eventData.event_data.message || null;
+	}
 }

--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
@@ -1,9 +1,23 @@
 import HelixSubscription, { HelixSubscriptionData } from './HelixSubscription';
 import TwitchClient from '../../../TwitchClient';
 
+/**
+ * The different types a subscription event can have.
+ */
 export enum HelixSubscriptionEventType {
+	/**
+	 * Sent when a new user subscribes.
+	 */
 	Subscribe = 'subscriptions.subscribe',
+
+	/**
+	 * Sent when a previous subscriber stops subscribing.
+	 */
 	Unsubscribe = 'subscriptions.unsubscribe',
+
+	/**
+	 * Sent when a new or recurring subscriber sends their monthly notification.
+	 */
 	Notification = 'subscriptions.notification'
 }
 
@@ -16,6 +30,9 @@ export interface HelixSubscriptionEventData {
 	event_data: HelixSubscriptionData;
 }
 
+/**
+ * An event that indicates the change of a subscription status, i.e. subscribing, unsubscribing or sending the monthly notification.
+ */
 export default class HelixSubscriptionEvent extends HelixSubscription {
 	/** @private */
 	constructor(private readonly _eventData: HelixSubscriptionEventData, client: TwitchClient) {
@@ -50,7 +67,10 @@ export default class HelixSubscriptionEvent extends HelixSubscription {
 		return this._eventData.version;
 	}
 
+	/**
+	 * The message sent with the subscription event.
+	 */
 	get eventMessage() {
-		return this._eventData.event_data.message || null;
+		return this._eventData.event_data.message || '';
 	}
 }

--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionEvent.ts
@@ -49,4 +49,8 @@ export default class HelixSubscriptionEvent extends HelixSubscription {
   get eventVersion() {
     return this._event_data.version;
   }
+
+  get eventMessage() {
+    return this._event_data.event_data.message || null;
+  }
 }

--- a/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
+++ b/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
@@ -270,13 +270,17 @@ export default class HelixWebHooksAPI extends BaseAPI {
 		});
 	}
 
-	private async _sendUserSubscriptionHubRequest(mode: HubMode, user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+	private async _sendUserSubscriptionHubRequest(
+		mode: HubMode,
+		user: UserIdResolvable,
+		options: HelixWebHookHubRequestOptions
+	) {
 		const userId = extractUserId(user);
 
 		return this.sendHubRequest({
 			mode,
 			topicUrl: `https://api.twitch.tv/helix/subscriptions/events?broadcaster_id=${userId}&first=1`,
 			...options
-		})
+		});
 	}
 }

--- a/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
+++ b/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
@@ -201,6 +201,30 @@ export default class HelixWebHooksAPI extends BaseAPI {
 		return this._sendUserChangeHubRequest('unsubscribe', user, options);
 	}
 
+	/**
+	 * Subscribes to events representing a channel subscription or unsubscription.
+	 *
+	 * @expandParams
+	 *
+	 * @param user The user for which to get notifications about subscriptions and unsubscriptions to their channel.
+	 * @param options
+	 */
+	async subscribeToUserSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+		return this._sendUserSubscriptionHubRequest('subscribe', user, options);
+	}
+
+	/**
+	 * Unsubscribes from events representing a channel subscription or unsubscription.
+	 *
+	 * @expandParams
+	 *
+	 * @param user The user for which to get notifications about subscriptions and unsubscriptions to their channel.
+	 * @param options
+	 */
+	async unsubscribeFromUserSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+		return this._sendUserSubscriptionHubRequest('unsubscribe', user, options);
+	}
+
 	private async _sendUserFollowsHubRequest(
 		mode: HubMode,
 		direction: 'from' | 'to',
@@ -244,5 +268,15 @@ export default class HelixWebHooksAPI extends BaseAPI {
 			scope: withEmail ? 'user:read:email' : undefined,
 			...options
 		});
+	}
+
+	private async _sendUserSubscriptionHubRequest(mode: HubMode, user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+		const userId = extractUserId(user);
+
+		return this.sendHubRequest({
+			mode,
+			topicUrl: `https://api.twitch.tv/helix/subscriptions/events?broadcaster_id=${userId}&first=1`,
+			...options
+		})
 	}
 }

--- a/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
+++ b/packages/twitch/src/API/Helix/WebHooks/HelixWebHooksAPI.ts
@@ -209,7 +209,7 @@ export default class HelixWebHooksAPI extends BaseAPI {
 	 * @param user The user for which to get notifications about subscriptions and unsubscriptions to their channel.
 	 * @param options
 	 */
-	async subscribeToUserSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+	async subscribeToSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
 		return this._sendUserSubscriptionHubRequest('subscribe', user, options);
 	}
 
@@ -221,7 +221,7 @@ export default class HelixWebHooksAPI extends BaseAPI {
 	 * @param user The user for which to get notifications about subscriptions and unsubscriptions to their channel.
 	 * @param options
 	 */
-	async unsubscribeFromUserSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
+	async unsubscribeFromSubscriptionEvents(user: UserIdResolvable, options: HelixWebHookHubRequestOptions) {
 		return this._sendUserSubscriptionHubRequest('unsubscribe', user, options);
 	}
 

--- a/packages/twitch/src/index.ts
+++ b/packages/twitch/src/index.ts
@@ -93,7 +93,7 @@ export { HelixVideo };
 import HelixSubscription from './API/Helix/Subscriptions/HelixSubscription';
 import HelixSubscriptionEvent from './API/Helix/Subscriptions/HelixSubscriptionEvent';
 
-export { HelixSubscription, HelixSubscriptionEvent }
+export { HelixSubscription, HelixSubscriptionEvent };
 
 import ChatBadgeList from './API/Badges/ChatBadgeList';
 import ChatBadgeSet from './API/Badges/ChatBadgeSet';

--- a/packages/twitch/src/index.ts
+++ b/packages/twitch/src/index.ts
@@ -90,6 +90,11 @@ import HelixVideo from './API/Helix/Video/HelixVideo';
 
 export { HelixVideo };
 
+import HelixSubscription from './API/Helix/Subscriptions/HelixSubscription';
+import HelixSubscriptionEvent from './API/Helix/Subscriptions/HelixSubscriptionEvent';
+
+export { HelixSubscription, HelixSubscriptionEvent }
+
 import ChatBadgeList from './API/Badges/ChatBadgeList';
 import ChatBadgeSet from './API/Badges/ChatBadgeSet';
 import ChatBadgeVersion from './API/Badges/ChatBadgeVersion';


### PR DESCRIPTION
https://dev.twitch.tv/docs/api/webhooks-reference/#topic-subscription-events

- Adds `SubscriptionEventSubscription` for twitch-webhooks
- Creates a new `HelixSubscriptionEvent` class that extends from `HelixSubscription` due to the way that the event's payload is structured.

Testing this was a bit difficult, but when sending some mock events with Postman, everything worked fine for me and the event fired properly.