### PR TITLE
Added event listener for msg_ratelimit

### DIFF
--- a/packages/twitch-chat-client/package.json
+++ b/packages/twitch-chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-chat-client",
-  "version": "3.4.3",
+  "version": "3.4.2",
   "description": "Interact with the Twitch Messaging Interface (aka Twitch chat).",
   "keywords": [
     "twitch",

--- a/packages/twitch-chat-client/package.json
+++ b/packages/twitch-chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-chat-client",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Interact with the Twitch Messaging Interface (aka Twitch chat).",
   "keywords": [
     "twitch",

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -335,16 +335,25 @@ export default class ChatClient extends IRCClient {
 	 *
 	 * @eventListener
 	 * @param channel The channel that a command without sufficient permissions was executed on.
-	 * @maram message The message text.
+	 * @param message The message text.
 	 */
 	onNoPermission: (handler: (channel: string, message: string) => void) => Listener = this.registerEvent();
+
+	/**
+	 * Fires when a message you tried to send gets rejected by the ratelimiter.
+	 *
+	 * @eventListener
+	 * @param channel The channel that was attempted to send to.
+	 * @param message The message text.
+	 */
+	onMessageRatelimit: (handler: (channel: string, message: string) => void) => Listener = this.registerEvent();
 
 	/**
 	 * Fires when authentication fails.
 	 *
 	 * @eventListener
 	 * @param channel The channel that a command without sufficient permissions was executed on.
-	 * @maram message The message text.
+	 * @param message The message text.
 	 */
 	onAuthenticationFailure: (handler: (message: string) => void) => Listener = this.registerEvent();
 
@@ -451,9 +460,6 @@ export default class ChatClient extends IRCClient {
 	) => Listener = this.registerEvent();
 	private readonly _onIntermediateAuthenticationFailure: (
 		handler: (message: string) => void
-	) => Listener = this.registerEvent();
-	private readonly _onMessageRatelimit: (
-		handler: (channel: string, message: string) => void
 	) => Listener = this.registerEvent();
 
 	/**
@@ -1101,7 +1107,7 @@ export default class ChatClient extends IRCClient {
 				}
 
 				case 'msg_ratelimit': {
-					this.emit(this._onMessageRatelimit, channel, message);
+					this.emit(this.onMessageRatelimit, channel, message);
 					break;
 				}
 

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -452,6 +452,9 @@ export default class ChatClient extends IRCClient {
 	private readonly _onIntermediateAuthenticationFailure: (
 		handler: (message: string) => void
 	) => Listener = this.registerEvent();
+	private readonly _onMessageRatelimit: (
+		handler: (channel: string, message: string) => void
+	) => Listener = this.registerEvent();
 
 	/**
 	 * Creates a new Twitch chat client with the user info from the TwitchClient instance.
@@ -1094,6 +1097,11 @@ export default class ChatClient extends IRCClient {
 
 				case 'no_permission': {
 					this.emit(this.onNoPermission, channel, message);
+					break;
+				}
+
+				case 'msg_ratelimit': {
+					this.emit(this._onMessageRatelimit, channel, message);
 					break;
 				}
 


### PR DESCRIPTION
This event is fired when a message fails to send due to internal twitch rate-limiting.