### PR TITLE
Fix missing Helix call type for SubscriptionsAPI

### DIFF
--- a/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionAPI.ts
+++ b/packages/twitch/src/API/Helix/Subscriptions/HelixSubscriptionAPI.ts
@@ -28,6 +28,7 @@ export default class HelixSubscriptionAPI extends BaseAPI {
 		const result = await this._client.callAPI<HelixPaginatedResponse<HelixSubscriptionData>>({
 			url: 'subscriptions',
 			scope: 'channel:read:subscriptions',
+			type: TwitchAPICallType.Helix,
 			query: {
 				broadcaster_id: extractUserId(broadcaster)
 			}


### PR DESCRIPTION
The default type of Kraken makes `twitchClient.helix.subscriptions.getSubscriptions` call `/kraken/subscriptions` which 404's and isn't the intended behavior.