### PR TITLE
[next] fix(twitch-webhooks): publish `es` directory

### DIFF
--- a/packages/twitch-webhooks/package.json
+++ b/packages/twitch-webhooks/package.json
@@ -43,7 +43,8 @@
   "files": [
     "LICENSE",
     "README.md",
-    "lib"
+    "lib",
+    "es"
   ],
   "scripts": {
     "build": "tsukuru",


### PR DESCRIPTION
Related to #122 

The published `twitch-webhooks` package is missing the `es` directory:

https://github.com/d-fischer/twitch/blob/eff58e113e2e8ac8228b4711f2a181e7131d8bd4/packages/twitch-webhooks/package.json#L43-L47