### PR TITLE
Allow custom hostnames

### DIFF
--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -640,9 +640,21 @@ export default class ChatClient extends IRCClient {
 	 */
 	constructor(twitchClient: TwitchClient | undefined, options: ChatClientOptions = {}) {
 		/* eslint-disable no-restricted-syntax */
+		let hostName = null;
+
+		if (options.webSocket === false) {
+			hostName = 'irc.chat.twitch.tv';
+		} else {
+			hostName = 'irc-ws.chat.twitch.tv';
+		}
+
+		if (options.hostName) {
+			hostName = options.hostName;
+		}
+
 		super({
 			connection: {
-				hostName: options.webSocket === false ? 'irc.chat.twitch.tv' : 'irc-ws.chat.twitch.tv',
+				hostName,
 				secure: options.ssl !== false
 			},
 			credentials: {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -647,7 +647,8 @@ export default class ChatClient extends IRCClient {
 		/* eslint-disable no-restricted-syntax */
 		super({
 			connection: {
-				hostName: options.hostName ?? (options.webSocket === false ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
+				hostName:
+					options.hostName ?? (options.webSocket === false ? 'irc.chat.twitch.tv' : 'irc-ws.chat.twitch.tv'),
 				secure: options.ssl !== false
 			},
 			credentials: {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -647,7 +647,7 @@ export default class ChatClient extends IRCClient {
 		/* eslint-disable no-restricted-syntax */
 		super({
 			connection: {
-				hostName: options.hostName || (options.webSocket ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
+				hostName: options.hostName ?? (options.webSocket ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
 				secure: options.ssl !== false
 			},
 			credentials: {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -70,6 +70,11 @@ export interface ChatClientOptions {
 	ssl?: boolean;
 
 	/**
+	 * Custom hostname for connecting to chat.
+	 */
+	hostName?: string;
+
+	/**
 	 * Whether to use a WebSocket to connect to chat.
 	 */
 	webSocket?: boolean;

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -645,21 +645,9 @@ export default class ChatClient extends IRCClient {
 	 */
 	constructor(twitchClient: TwitchClient | undefined, options: ChatClientOptions = {}) {
 		/* eslint-disable no-restricted-syntax */
-		let hostName = null;
-
-		if (options.webSocket === false) {
-			hostName = 'irc.chat.twitch.tv';
-		} else {
-			hostName = 'irc-ws.chat.twitch.tv';
-		}
-
-		if (options.hostName) {
-			hostName = options.hostName;
-		}
-
 		super({
 			connection: {
-				hostName,
+				hostName: options.hostName || (options.webSocket ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
 				secure: options.ssl !== false
 			},
 			credentials: {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -647,7 +647,7 @@ export default class ChatClient extends IRCClient {
 		/* eslint-disable no-restricted-syntax */
 		super({
 			connection: {
-				hostName: options.hostName ?? (options.webSocket ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
+				hostName: options.hostName ?? (options.webSocket === false ? 'irc-ws.chat.twitch.tv' : 'irc.chat.twitch.tv'),
 				secure: options.ssl !== false
 			},
 			credentials: {


### PR DESCRIPTION
Adds the ability for `ChatClient` to receive a custom `hostName`.

Fixes #132 