### PR TITLE
Add rewardImage to PubSubRedemptionMessage

### DIFF
--- a/packages/twitch-pubsub-client/src/Messages/PubSubRedemptionMessage.ts
+++ b/packages/twitch-pubsub-client/src/Messages/PubSubRedemptionMessage.ts
@@ -154,6 +154,13 @@ export default class PubSubRedemptionMessage {
 	}
 
 	/**
+	 * The image set associated with the reward.
+	 */
+	get rewardImage() {
+		return this._data.data.redemption.reward.image;
+	}
+
+	/**
 	 * The full message that was sent with the notification.
 	 */
 	get message() {


### PR DESCRIPTION
Type: Feature

Fixes: #147 

This adds a `rewardImage` getter to the `PubSubRedemptionMessage` class so it's possible to obtain the image set associated with redeemed reward.