### PR TITLE
Fix reconnection issue with expired tokens

### DIFF
--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1372,10 +1372,11 @@ export class ChatClient extends IrcClient {
 						message === 'Improperly formatted AUTH' ||
 						message === 'Invalid NICK'
 					) {
-						this._authVerified = false;
 						this._authFailureMessage = message;
 						this.emit(this.onAuthenticationFailure, message);
-						this._connection!.disconnect();
+						// Attempt to reconnect right away if auth was previously valid, else wait 5 seconds to avoid spamming
+						setTimeout(async () => this.reconnect(), this._authVerified ? 0 : 5000);
+						this._authVerified = false;
 					}
 					break;
 				}


### PR DESCRIPTION
Type: Bugfix
Fixes: #161

Changes the client so that instead of manually disconnecting after an auth failure, it will instead try to reconnect.

If the auth was previously valid, then the most likely case is that the existing auth token which was previously used and verified has expired. In this case, it will attempt a reconnect right away.

If the auth was previously invalid, or never verified, it instead waits 5 seconds before reconnecting so that fetching auth/reconnecting is not spammed.

I have manually tested this personally, and it fixes the reconnection issue for me as described in #161