### PR TITLE
Throw errors for incorrect chat command parameters

### DIFF
--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1662,24 +1662,25 @@ export class ChatClient extends IrcClient {
 	 */
 	async enableFollowersOnly(channel: string, minFollowTime: number = 0): Promise<void> {
 		if (!Number.isInteger(minFollowTime) || minFollowTime < 0 || minFollowTime > 129600) {
-			this.emit(this._onFollowersOnlyResult, channel, minFollowTime, 'bad_follow_time');
+			throw new Error(
+				`Invalid minimum follow time: ${minFollowTime}. It must be an integer between 0 and 129600.`
+			);
 			return undefined;
-		} else {
-			channel = toUserName(channel);
-			return new Promise<void>((resolve, reject) => {
-				const e = this._onFollowersOnlyResult((_channel, _minFollowTime, error) => {
-					if (toUserName(_channel) === channel && _minFollowTime === minFollowTime) {
-						if (error) {
-							reject(error);
-						} else {
-							resolve();
-						}
-						this.removeListener(e);
-					}
-				});
-				this.say(channel, `/followers ${minFollowTime || ''}`);
-			});
 		}
+		channel = toUserName(channel);
+		return new Promise<void>((resolve, reject) => {
+			const e = this._onFollowersOnlyResult((_channel, _minFollowTime, error) => {
+				if (toUserName(_channel) === channel && _minFollowTime === minFollowTime) {
+					if (error) {
+						reject(error);
+					} else {
+						resolve();
+					}
+					this.removeListener(e);
+				}
+			});
+			this.say(channel, `/followers ${minFollowTime || ''}`);
+		});
 	}
 
 	/**
@@ -1822,24 +1823,25 @@ export class ChatClient extends IrcClient {
 	 */
 	async enableSlow(channel: string, delayBetweenMessages: number = 30): Promise<void> {
 		if (!Number.isInteger(delayBetweenMessages) || delayBetweenMessages < 1 || delayBetweenMessages > 1800) {
-			this.emit(this._onSlowResult, channel, delayBetweenMessages, 'bad_slow_duration');
+			throw new Error(
+				`Invalid delay between messages: ${delayBetweenMessages}. It must be an integer between 1 and 1800.`
+			);
 			return undefined;
-		} else {
-			channel = toUserName(channel);
-			return new Promise<void>((resolve, reject) => {
-				const e = this._onSlowResult((_channel, _delay, error) => {
-					if (toUserName(_channel) === channel) {
-						if (error) {
-							reject(error);
-						} else {
-							resolve();
-						}
-						this.removeListener(e);
-					}
-				});
-				this.say(channel, `/slow ${delayBetweenMessages}`);
-			});
 		}
+		channel = toUserName(channel);
+		return new Promise<void>((resolve, reject) => {
+			const e = this._onSlowResult((_channel, _delay, error) => {
+				if (toUserName(_channel) === channel) {
+					if (error) {
+						reject(error);
+					} else {
+						resolve();
+					}
+					this.removeListener(e);
+				}
+			});
+			this.say(channel, `/slow ${delayBetweenMessages}`);
+		});
 	}
 
 	/**
@@ -1917,25 +1919,24 @@ export class ChatClient extends IrcClient {
 	 * @param reason
 	 */
 	async timeout(channel: string, user: string, duration: number = 60, reason: string = ''): Promise<void> {
-		if (!Number.isInteger(duration) || duration < 0 || duration > 1209600) {
-			this.emit(this._onTimeoutResult, channel, user, duration, 'bad_timeout_time');
+		if (!Number.isInteger(duration) || duration < 1 || duration > 1209600) {
+			throw new Error(`Invalid timeout duration: ${duration}. It must be an integer between 1 and 1209600.`);
 			return undefined;
-		} else {
-			channel = toUserName(channel);
-			return new Promise<void>((resolve, reject) => {
-				const e = this._onTimeoutResult((_channel, _user, _duration, error) => {
-					if (toUserName(_channel) === channel && toUserName(_user) === user) {
-						if (error) {
-							reject(error);
-						} else {
-							resolve();
-						}
-						this.removeListener(e);
-					}
-				});
-				this.say(channel, `/timeout ${user} ${duration} ${reason}`);
-			});
 		}
+		channel = toUserName(channel);
+		return new Promise<void>((resolve, reject) => {
+			const e = this._onTimeoutResult((_channel, _user, _duration, error) => {
+				if (toUserName(_channel) === channel && toUserName(_user) === user) {
+					if (error) {
+						reject(error);
+					} else {
+						resolve();
+					}
+					this.removeListener(e);
+				}
+			});
+			this.say(channel, `/timeout ${user} ${duration} ${reason}`);
+		});
 	}
 
 	/**

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1816,20 +1816,24 @@ export class ChatClient extends IrcClient {
 	 * @param delayBetweenMessages The time (in seconds) a user needs to wait between messages.
 	 */
 	async enableSlow(channel: string, delayBetweenMessages: number = 30): Promise<void> {
-		channel = toUserName(channel);
-		return new Promise<void>((resolve, reject) => {
-			const e = this._onSlowResult((_channel, _delay, error) => {
-				if (toUserName(_channel) === channel) {
-					if (error) {
-						reject(error);
-					} else {
-						resolve();
+		if (!Number.isInteger(delayBetweenMessages) || delayBetweenMessages < 1 || delayBetweenMessages > 1800) {
+			return void this.emit(this._onSlowResult, channel, delayBetweenMessages, 'bad_slow_duration');
+		} else {
+			channel = toUserName(channel);
+			return new Promise<void>((resolve, reject) => {
+				const e = this._onSlowResult((_channel, _delay, error) => {
+					if (toUserName(_channel) === channel) {
+						if (error) {
+							reject(error);
+						} else {
+							resolve();
+						}
+						this.removeListener(e);
 					}
-					this.removeListener(e);
-				}
+				});
+				this.say(channel, `/slow ${delayBetweenMessages}`);
 			});
-			this.say(channel, `/slow ${delayBetweenMessages}`);
-		});
+		}
 	}
 
 	/**

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1915,20 +1915,24 @@ export class ChatClient extends IrcClient {
 	 * @param reason
 	 */
 	async timeout(channel: string, user: string, duration: number = 60, reason: string = ''): Promise<void> {
-		channel = toUserName(channel);
-		return new Promise<void>((resolve, reject) => {
-			const e = this._onTimeoutResult((_channel, _user, _duration, error) => {
-				if (toUserName(_channel) === channel && toUserName(_user) === user) {
-					if (error) {
-						reject(error);
-					} else {
-						resolve();
+		if (!Number.isInteger(duration) || duration < 0 || duration > 1209600) {
+			return void this.emit(this._onTimeoutResult, channel, user, duration, 'bad_timeout_time');
+		} else {
+			channel = toUserName(channel);
+			return new Promise<void>((resolve, reject) => {
+				const e = this._onTimeoutResult((_channel, _user, _duration, error) => {
+					if (toUserName(_channel) === channel && toUserName(_user) === user) {
+						if (error) {
+							reject(error);
+						} else {
+							resolve();
+						}
+						this.removeListener(e);
 					}
-					this.removeListener(e);
-				}
+				});
+				this.say(channel, `/timeout ${user} ${duration} ${reason}`);
 			});
-			this.say(channel, `/timeout ${user} ${duration} ${reason}`);
-		});
+		}
 	}
 
 	/**

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1665,7 +1665,6 @@ export class ChatClient extends IrcClient {
 			throw new Error(
 				`Invalid minimum follow time: ${minFollowTime}. It must be an integer between 0 and 129600.`
 			);
-			return undefined;
 		}
 		channel = toUserName(channel);
 		return new Promise<void>((resolve, reject) => {
@@ -1826,7 +1825,6 @@ export class ChatClient extends IrcClient {
 			throw new Error(
 				`Invalid delay between messages: ${delayBetweenMessages}. It must be an integer between 1 and 1800.`
 			);
-			return undefined;
 		}
 		channel = toUserName(channel);
 		return new Promise<void>((resolve, reject) => {
@@ -1921,7 +1919,6 @@ export class ChatClient extends IrcClient {
 	async timeout(channel: string, user: string, duration: number = 60, reason: string = ''): Promise<void> {
 		if (!Number.isInteger(duration) || duration < 1 || duration > 1209600) {
 			throw new Error(`Invalid timeout duration: ${duration}. It must be an integer between 1 and 1209600.`);
-			return undefined;
 		}
 		channel = toUserName(channel);
 		return new Promise<void>((resolve, reject) => {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1662,7 +1662,7 @@ export class ChatClient extends IrcClient {
 	 */
 	async enableFollowersOnly(channel: string, minFollowTime: number = 0): Promise<void> {
 		if (!Number.isInteger(minFollowTime) || minFollowTime < 0 || minFollowTime > 129600) {
-			return void this.emit(this._onSlowResult, channel, minFollowTime, 'bad_follow_time');
+			return void this.emit(this._onFollowersOnlyResult, channel, minFollowTime, 'bad_follow_time');
 		} else {
 			channel = toUserName(channel);
 			return new Promise<void>((resolve, reject) => {

--- a/packages/twitch-chat-client/src/ChatClient.ts
+++ b/packages/twitch-chat-client/src/ChatClient.ts
@@ -1662,7 +1662,8 @@ export class ChatClient extends IrcClient {
 	 */
 	async enableFollowersOnly(channel: string, minFollowTime: number = 0): Promise<void> {
 		if (!Number.isInteger(minFollowTime) || minFollowTime < 0 || minFollowTime > 129600) {
-			return void this.emit(this._onFollowersOnlyResult, channel, minFollowTime, 'bad_follow_time');
+			this.emit(this._onFollowersOnlyResult, channel, minFollowTime, 'bad_follow_time');
+			return undefined;
 		} else {
 			channel = toUserName(channel);
 			return new Promise<void>((resolve, reject) => {
@@ -1821,7 +1822,8 @@ export class ChatClient extends IrcClient {
 	 */
 	async enableSlow(channel: string, delayBetweenMessages: number = 30): Promise<void> {
 		if (!Number.isInteger(delayBetweenMessages) || delayBetweenMessages < 1 || delayBetweenMessages > 1800) {
-			return void this.emit(this._onSlowResult, channel, delayBetweenMessages, 'bad_slow_duration');
+			this.emit(this._onSlowResult, channel, delayBetweenMessages, 'bad_slow_duration');
+			return undefined;
 		} else {
 			channel = toUserName(channel);
 			return new Promise<void>((resolve, reject) => {
@@ -1916,7 +1918,8 @@ export class ChatClient extends IrcClient {
 	 */
 	async timeout(channel: string, user: string, duration: number = 60, reason: string = ''): Promise<void> {
 		if (!Number.isInteger(duration) || duration < 0 || duration > 1209600) {
-			return void this.emit(this._onTimeoutResult, channel, user, duration, 'bad_timeout_time');
+			this.emit(this._onTimeoutResult, channel, user, duration, 'bad_timeout_time');
+			return undefined;
 		} else {
 			channel = toUserName(channel);
 			return new Promise<void>((resolve, reject) => {

--- a/packages/twitch-chat-client/src/Toolkit/UserTools.ts
+++ b/packages/twitch-chat-client/src/Toolkit/UserTools.ts
@@ -1,7 +1,15 @@
 /** @private */
 export function toUserName(channel: string): string {
 	// it's okay if this is already a user name, we only remove the first character if it's a pound
-	return channel.replace(/^#/, '').toLowerCase();
+	const name = channel.replace(/^#/, '').toLowerCase();
+	// valid usernames must be alphanumberic or underscores between 4 and 25 characters (cannot start with underscore)
+	const re = RegExp(/^[a-zA-Z0-9][a-zA-Z0-9_]{3,24}$/);
+	if (!re.test(name)) {
+		throw new Error(
+			'Invalid channel or username. It must be made from alphanumberic characters and between 4 and 25 characters in length. Usernames and channels names cannot start with an underscore.'
+		);
+	}
+	return name;
 }
 
 /** @private */

--- a/packages/twitch-chat-client/src/Toolkit/UserTools.ts
+++ b/packages/twitch-chat-client/src/Toolkit/UserTools.ts
@@ -1,12 +1,13 @@
+// valid names must be alphanumberic or underscores between 4 and 25 characters (cannot start with underscore)
+const validNames = /^[a-zA-Z0-9][a-zA-Z0-9_]{3,24}$/;
+
 /** @private */
 export function toUserName(channel: string): string {
 	// it's okay if this is already a user name, we only remove the first character if it's a pound
 	const name = channel.replace(/^#/, '').toLowerCase();
-	// valid usernames must be alphanumberic or underscores between 4 and 25 characters (cannot start with underscore)
-	const re = RegExp(/^[a-zA-Z0-9][a-zA-Z0-9_]{3,24}$/);
-	if (!re.test(name)) {
+	if (!validNames.test(name)) {
 		throw new Error(
-			'Invalid channel or username. It must be made from alphanumberic characters and between 4 and 25 characters in length. Usernames and channels names cannot start with an underscore.'
+			'"$[name}" is not a valid user or channel name. It must be 4-25 characters long, can only include letters, numbers and underscores, and can not start with an underscore.'
 		);
 	}
 	return name;


### PR DESCRIPTION
Type: Feature


Fixes: #138


- `enableSlow()` - Checks delay is an integer between 1 and 1800.
- `enableFollowersOnly()` - Checks delay is an integer between 0 and 129600.
- `timeout()` - Checks duration is an integer between 1 and 1209600.


This does not currently complete whole issue. The issue also requires a sanity check of usernames and channel names to be resolved. 
