### PR TITLE
Add startDate to StreamOnline EventSub event

### DIFF
--- a/packages/twitch-eventsub/src/Events/EventSubStreamOnlineEvent.ts
+++ b/packages/twitch-eventsub/src/Events/EventSubStreamOnlineEvent.ts
@@ -11,6 +11,7 @@ export interface EventSubStreamOnlineEventData {
 	broadcaster_user_login: string;
 	broadcaster_user_name: string;
 	type: EventSubStreamOnlineEventStreamType;
+	started_at: string;
 }
 
 /**
@@ -60,5 +61,12 @@ export class EventSubStreamOnlineEvent {
 	 */
 	get streamType(): EventSubStreamOnlineEventStreamType {
 		return this._data.type;
+	}
+
+	/**
+	 * The date and time when the stream was started.
+	 */
+	get startDate(): Date {
+		return new Date(this._data.started_at);
 	}
 }


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Improvement
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #218

<!-- Here you can explain in further detail what your pull request contains. -->

Adds a "startDate" getter for the new `started_at` property of the StreamOnline EventSub event.