### PR TITLE
Fix EventSub unsubscriptions by removing code relevant for the Webhooks implementation

### DIFF
--- a/packages/twitch-eventsub/src/Subscriptions/EventSubSubscription.ts
+++ b/packages/twitch-eventsub/src/Subscriptions/EventSubSubscription.ts
@@ -16,7 +16,6 @@ export type SubscriptionResultType<T extends EventSubSubscription> = T extends E
 export abstract class EventSubSubscription</** @private */ T = any> {
 	private _verified: boolean = false;
 	private _twitchSubscriptionData?: HelixEventSubSubscription;
-	private _unsubscribeResolver?: () => void;
 
 	/** @private */
 	protected constructor(protected _handler: (obj: T) => void, protected _client: EventSubListener) {}
@@ -59,16 +58,6 @@ export abstract class EventSubSubscription</** @private */ T = any> {
 		this._handler(this.transformData(body));
 	}
 
-	/** @private */
-	_handleUnsubscribe(): boolean {
-		if (this._unsubscribeResolver) {
-			this._unsubscribeResolver();
-			this._unsubscribeResolver = undefined;
-			return true;
-		}
-		return false;
-	}
-
 	/**
 	 * Activates the subscription.
 	 */
@@ -94,9 +83,7 @@ export abstract class EventSubSubscription</** @private */ T = any> {
 		if (!this._twitchSubscriptionData) {
 			return;
 		}
-		const unsubscribePromise = new Promise<void>(resolve => (this._unsubscribeResolver = resolve));
 		await this._unsubscribe();
-		await unsubscribePromise;
 		this._twitchSubscriptionData = undefined;
 	}
 


### PR DESCRIPTION
Type: **Bugfix**

Fixes: discussed on Discord
> Relevant messages:
> * https://discord.com/channels/325552783787032576/350012219003764748/807358365025697852
> * https://discord.com/channels/325552783787032576/350012219003764748/807379612887547945
> * https://discord.com/channels/325552783787032576/350012219003764748/807437261817118741

While trying to implement graceful exiting for my app using the `twitch-eventsub` package, I noticed that the `Promise` returned from unsubscription calls for `EventSub` listeners never seem to get resolved or rejected.
It seems that the initial `EventSub` implementation included code copied over from the `Webhooks` functionality and assumed that Twitch sent an unsubscription confirmation message. ([Webhooks reference](https://dev.twitch.tv/docs/api/webhooks-reference#json-body-parameters), not the `hub.mode` values).

Although, unsubscribing from `EventSub` subscriptions works by just checking the HTTP status code Twitch replies with ([reference](https://dev.twitch.tv/docs/eventsub#delete-a-subscription)).

This PR removes the relevant code that would wait for an unsubscription notification, as the API call functionality already covers validation of the correct HTTP status.

---
If I missed anything, please let me know. This is my first contribution to this repository.