### PR TITLE
add EventSub ban/unban props: mod,reason,end,perm

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ const baseRules = require('@d-fischer/eslint-config');
 const memberNames = [
 	// Twitch API
 	'_(id|name|at)$',
-	'^(broadcaster_)?user_login$',
+	'^(broadcaster_|moderator_)?user_login$',
 	'^(broadcaster|gifter|from|to)_login$',
 	'^client_secret$',
 	'^redirect_uri$',
@@ -25,7 +25,7 @@ const memberNames = [
 	'^click_action$',
 	'^(image_)?url_\\dx$',
 	'^emoticon_sets?$',
-	'^is_(anonymous|gift|user_input_required|sub_only|mature|enabled|paused|in_stock|previewable|playlist|(verified|known)_bot|live|auto)$',
+	'^is_(anonymous|gift|user_input_required|sub_only|mature|enabled|paused|in_stock|previewable|playlist|(verified|known)_bot|live|auto|permanent)$',
 	'^minimum_allowed_role$',
 	'^(chatter|view(er)?)_count$',
 	'^min_bits$',

--- a/packages/twitch-eventsub/src/Events/EventSubChannelBanEvent.ts
+++ b/packages/twitch-eventsub/src/Events/EventSubChannelBanEvent.ts
@@ -10,6 +10,12 @@ export interface EventSubChannelBanEventData {
 	broadcaster_user_id: string;
 	broadcaster_user_login: string;
 	broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
+	reason: string;
+	ends_at: string | null;
+	is_permanent: boolean;
 }
 
 /**
@@ -79,5 +85,54 @@ export class EventSubChannelBanEvent {
 	 */
 	async getBroadcaster(): Promise<HelixUser> {
 		return (await this._client.helix.users.getUserById(this._data.broadcaster_user_id))!;
+	}
+
+	/**
+	 * The ID of the moderator who issued the ban/timeout.
+	 */
+	get moderatorId(): string {
+		return this._data.moderator_user_id;
+	}
+
+	/**
+	 * The name of the moderator who issued the ban/timeout.
+	 */
+	get moderatorName(): string {
+		return this._data.moderator_user_login;
+	}
+
+	/**
+	 * The display name of the moderator who issued the ban/timeout.
+	 */
+	get moderatorDisplayName(): string {
+		return this._data.moderator_user_name;
+	}
+
+	/**
+	 * Retrieves more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return (await this._client.helix.users.getUserById(this._data.moderator_user_id))!;
+	}
+
+	/**
+	 * The reason behind the ban.
+	 */
+	get reason(): string {
+		return this._data.reason;
+	}
+
+	/**
+	 * If it is a timeout, the date and time when the timeout will end. Will be null if permanent ban.
+	 */
+	get endDate(): Date | null {
+		return this._data.ends_at ? new Date(this._data.ends_at) : null;
+	}
+
+	/**
+	 * Whether the ban is permanent.
+	 */
+	get isPermanent(): boolean {
+		return this._data.is_permanent;
 	}
 }

--- a/packages/twitch-eventsub/src/Events/EventSubChannelUnbanEvent.ts
+++ b/packages/twitch-eventsub/src/Events/EventSubChannelUnbanEvent.ts
@@ -10,6 +10,9 @@ export interface EventSubChannelUnbanEventData {
 	broadcaster_user_id: string;
 	broadcaster_user_login: string;
 	broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
 }
 
 /**
@@ -79,5 +82,33 @@ export class EventSubChannelUnbanEvent {
 	 */
 	async getBroadcaster(): Promise<HelixUser> {
 		return (await this._client.helix.users.getUserById(this._data.broadcaster_user_id))!;
+	}
+
+	/**
+	 * The ID of the moderator who issued the unban.
+	 */
+	get moderatorId(): string {
+		return this._data.moderator_user_id;
+	}
+
+	/**
+	 * The name of the moderator who issued the unban.
+	 */
+	get moderatorName(): string {
+		return this._data.moderator_user_login;
+	}
+
+	/**
+	 * The display name of the moderator who issued the unban.
+	 */
+	get moderatorDisplayName(): string {
+		return this._data.moderator_user_name;
+	}
+
+	/**
+	 * Retrieves more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return (await this._client.helix.users.getUserById(this._data.moderator_user_id))!;
 	}
 }


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Improvement
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #226

This PR adds:
- New EventSub `channel.ban` properties
  - Moderator user ID/login/display name getters, `getModerator`
  - `reason`
  - `endDate` - Will be `null` for timeouts.
  - `isPermanent`
- New EventSub `channel.unban` properties
  - Moderator user ID/login/display name getters, `getModerator`
- Additional `.eslintrc` exceptions