### PR TITLE
feat: Add Web-Standard EventSub Server based on H3 v2

### DIFF
--- a/packages/eventsub-http/package.json
+++ b/packages/eventsub-http/package.json
@@ -42,8 +42,10 @@
     "@twurple/common": "7.4.0",
     "@twurple/eventsub-base": "7.4.0",
     "@types/express-serve-static-core": "^4.17.24",
+    "h3": "^2.0.0-beta.3",
     "httpanda": "^0.4.6",
-    "tslib": "^2.0.3"
+    "tslib": "^2.0.3",
+    "srvx": "^0.8.5"
   },
   "devDependencies": {
     "@twurple/api": "7.4.0"

--- a/packages/eventsub-http/src/adapters/ConnectionAdapter.ts
+++ b/packages/eventsub-http/src/adapters/ConnectionAdapter.ts
@@ -1,4 +1,5 @@
-import * as http from 'http';
+import {type Server, serve} from 'srvx';
+import { type H3 } from 'h3';
 
 /**
  * An abstraction of a WebHook connection adapter.
@@ -7,10 +8,15 @@ export abstract class ConnectionAdapter {
 	/**
 	 * Creates the HTTP server to use for listening to events.
 	 *
+	 * @param app
+	 * @param port
 	 * @protected
 	 */
-	createHttpServer(): http.Server {
-		return http.createServer();
+	createHttpServer(app: H3, port: number): Server {
+		return serve({
+			fetch: app.fetch,
+			port,
+		})
 	}
 
 	/**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
 		"composite": true,
 		"module": "commonjs",
 		"target": "es2019",
-		"lib": ["es2019", "es2021.promise", "es2022.error"],
+		"lib": ["dom", "es2019", "es2021.promise", "es2022.error"],
 		"moduleResolution": "node",
 		"declaration": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Feature
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE!
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #640 

<!-- Here you can explain in further detail what your pull request contains. -->
This PR replaces the current express-compatible server with a Web-Standard one (h3's v2 beta).

It still needs more work before being merged
- [ ] The `srvx` package uses path imports, which don't work with the current build config. This also means I haven't been able to test this yet.
- [ ] All adapters need to be tested, as well as the ability to mount it into web-standard servers.
- [ ] I added a temporary `.getApp()` function to the middleware which can be used for testing, but this should probably be its own adapter instead(?)
- [ ] Updating certificates with the current HTTPS adapter won't work, this might need to be fixed at the `srvx` level
- [ ]  I would definitely wait until H3 v2 is out of beta