### PR TITLE
Access bit amount in easy-bot messages

### DIFF
--- a/packages/easy-bot/src/events/MessageEvent.ts
+++ b/packages/easy-bot/src/events/MessageEvent.ts
@@ -99,7 +99,7 @@ export class MessageEvent {
 	}
 
 	/**
-	 * The number of bits that have been cheered in the message.
+	 * The number of bits cheered with the message.
 	 */
 	get bits(): number {
 		return this._msg.bits;


### PR DESCRIPTION
Type: Improvement
Fixes: #653

Includes the bits getter for the message into the MessageEvent