### PR TITLE
Add Watch Streaks to chat notification event

### DIFF
--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
@@ -14,6 +14,7 @@ export type EventSubChannelChatNotificationType =
 	| 'announcement'
 	| 'bits_badge_tier'
 	| 'charity_donation'
+	| 'watch_streak'
 	| 'shared_chat_sub'
 	| 'shared_chat_resub'
 	| 'shared_chat_sub_gift'
@@ -213,6 +214,19 @@ export interface EventSubChannelChatBitsBadgeTierNotificationEventData
 }
 
 /** @private */
+interface EventSubChannelChatWatchStreakNotificationPayload {
+	streak_count: number;
+	channel_points_awarded: number;
+}
+
+/** @private */
+export interface EventSubChannelChatWatchStreakNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'watch_streak';
+	watch_streak: EventSubChannelChatWatchStreakNotificationPayload;
+}
+
+/** @private */
 export interface EventSubChannelChatSharedChatSubNotificationEventData
 	extends EventSubChannelChatBaseNotificationEventData {
 	notice_type: 'shared_chat_sub';
@@ -289,6 +303,7 @@ export type EventSubChannelChatNotificationEventData =
 	| EventSubChannelChatAnnouncementNotificationEventData
 	| EventSubChannelChatCharityDonationNotificationEventData
 	| EventSubChannelChatBitsBadgeTierNotificationEventData
+	| EventSubChannelChatWatchStreakNotificationEventData
 	| EventSubChannelChatSharedChatSubNotificationEventData
 	| EventSubChannelChatSharedChatResubNotificationEventData
 	| EventSubChannelChatSharedChatSubGiftNotificationEventData

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.ts
@@ -10,6 +10,7 @@ import { type EventSubChannelChatResubNotificationEvent } from './EventSubChanne
 import { type EventSubChannelChatSubGiftNotificationEvent } from './EventSubChannelChatSubGiftNotificationEvent.js';
 import { type EventSubChannelChatSubNotificationEvent } from './EventSubChannelChatSubNotificationEvent.js';
 import { type EventSubChannelChatUnraidNotificationEvent } from './EventSubChannelChatUnraidNotificationEvent.js';
+import { type EventSubChannelChatWatchStreakNotificationEvent } from './EventSubChannelChatWatchStreakNotificationEvent.js';
 import { type EventSubChannelChatSharedChatPayItForwardNotificationEvent } from './EventSubChannelChatSharedChatPayItForwardNotificationEvent.js';
 import { type EventSubChannelChatSharedChatSubNotificationEvent } from './EventSubChannelChatSharedChatSubNotificationEvent.js';
 import { type EventSubChannelChatSharedChatResubNotificationEvent } from './EventSubChannelChatSharedChatResubNotificationEvent.js';
@@ -33,6 +34,7 @@ export type EventSubChannelChatNotificationEvent =
 	| EventSubChannelChatAnnouncementNotificationEvent
 	| EventSubChannelChatCharityDonationNotificationEvent
 	| EventSubChannelChatBitsBadgeTierNotificationEvent
+	| EventSubChannelChatWatchStreakNotificationEvent
 	| EventSubChannelChatSharedChatSubNotificationEvent
 	| EventSubChannelChatSharedChatResubNotificationEvent
 	| EventSubChannelChatSharedChatSubGiftNotificationEvent

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatWatchStreakNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatWatchStreakNotificationEvent.ts
@@ -1,0 +1,31 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent.js';
+import { type EventSubChannelChatWatchStreakNotificationEventData } from './EventSubChannelChatNotificationEvent.external.js';
+
+/**
+ * An EventSub event representing a Watch Streak notification in a channel's chat.
+ */
+@rtfm<EventSubChannelChatWatchStreakNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatWatchStreakNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatWatchStreakNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatWatchStreakNotificationEventData;
+
+	readonly type = 'watch_streak' as const;
+
+	/**
+	 * The number of consecutive broadcasts for which the user has been watching.
+	 */
+	get streakCount(): number {
+		return this[rawDataSymbol].watch_streak.streak_count;
+	}
+
+	/**
+	 * The number of channel points awarded for the Watch Streak milestone.
+	 */
+	get channelPointsAwarded(): number {
+		return this[rawDataSymbol].watch_streak.channel_points_awarded;
+	}
+}

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -40,6 +40,7 @@ export { EventSubChannelChatPayItForwardNotificationEvent } from './events/chatN
 export { EventSubChannelChatAnnouncementNotificationEvent } from './events/chatNotifications/EventSubChannelChatAnnouncementNotificationEvent.js';
 export { EventSubChannelChatCharityDonationNotificationEvent } from './events/chatNotifications/EventSubChannelChatCharityDonationNotificationEvent.js';
 export { EventSubChannelChatBitsBadgeTierNotificationEvent } from './events/chatNotifications/EventSubChannelChatBitsBadgeTierNotificationEvent.js';
+export { EventSubChannelChatWatchStreakNotificationEvent } from './events/chatNotifications/EventSubChannelChatWatchStreakNotificationEvent.js';
 export { EventSubChannelChatSharedChatSubNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatSubNotificationEvent.js';
 export { EventSubChannelChatSharedChatResubNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatResubNotificationEvent.js';
 export { EventSubChannelChatSharedChatSubGiftNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatSubGiftNotificationEvent.js';

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatNotificationSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatNotificationSubscription.ts
@@ -23,6 +23,7 @@ import { EventSubChannelChatSharedChatSubNotificationEvent } from '../events/cha
 import { EventSubChannelChatSubGiftNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSubGiftNotificationEvent.js';
 import { EventSubChannelChatSubNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSubNotificationEvent.js';
 import { EventSubChannelChatUnraidNotificationEvent } from '../events/chatNotifications/EventSubChannelChatUnraidNotificationEvent.js';
+import { EventSubChannelChatWatchStreakNotificationEvent } from '../events/chatNotifications/EventSubChannelChatWatchStreakNotificationEvent.js';
 import type { EventSubBase } from '../EventSubBase.js';
 import { EventSubSubscription } from './EventSubSubscription.js';
 
@@ -109,6 +110,11 @@ export class EventSubChannelChatNotificationSubscription extends EventSubSubscri
 				return this._client._config.managed
 					? new EventSubChannelChatBitsBadgeTierNotificationEvent(data, this._client._config.apiClient)
 					: new EventSubChannelChatBitsBadgeTierNotificationEvent(data);
+
+			case 'watch_streak':
+				return this._client._config.managed
+					? new EventSubChannelChatWatchStreakNotificationEvent(data, this._client._config.apiClient)
+					: new EventSubChannelChatWatchStreakNotificationEvent(data);
 
 			case 'shared_chat_sub':
 				return this._client._config.managed


### PR DESCRIPTION
Type: Feature

Fixes: #667 

Adds watch streaks to EventSub `channel.chat.notification` event (see [Twitch docs](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#channel-chat-notification-event))
