### PR TITLE
Make `reason` optional in `ApiClient.moderation.banUser`

### DIFF
--- a/packages/api/src/interfaces/endpoints/moderation.input.ts
+++ b/packages/api/src/interfaces/endpoints/moderation.input.ts
@@ -52,7 +52,7 @@ export interface HelixBanUserRequest {
 	/**
 	 * The reason why the user is being timed out/banned.
 	 */
-	reason: string;
+	reason?: string;
 
 	/**
 	 * The user who is to be banned/timed out.


### PR DESCRIPTION
Type: Bugfix

Fixes: #669

