### PR TITLE
Fix EventSubChannelAdBreakBeginSubscription wrong _cliName

### DIFF
--- a/packages/eventsub-base/src/subscriptions/EventSubChannelAdBreakBeginSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelAdBreakBeginSubscription.ts
@@ -8,7 +8,7 @@ import { EventSubSubscription } from './EventSubSubscription.js';
 /** @internal */
 @rtfm('eventsub-base', 'EventSubSubscription')
 export class EventSubChannelAdBreakBeginSubscription extends EventSubSubscription<EventSubChannelAdBreakBeginEvent> {
-	/** @protected */ readonly _cliName = 'ad-break-begin';
+	/** @protected */ readonly _cliName = 'channel.ad_break.begin';
 
 	constructor(
 		handler: (data: EventSubChannelAdBreakBeginEvent) => void,


### PR DESCRIPTION
Type: Bugfix
Fixes: #

Fixes wrong `_cliName` for  `EventSubChannelAdBreakBeginSubscription` that is also returned through  `getCliTestCommand()`.

The latest twitch-cli (v1.1.24) (tested on Windows10) returns `Invalid event` for 
`twitch event trigger ad-break-begin -T webhook -F https://.../eventsub/event/channel.ad_break.begin.12345 -s *secret*`,
but is firing correctly when using `channel.ad_break.begin` 
(e.g. through `cliTestComandStr.replace('ad-break-begin', 'channel.ad_break.begin')` on the current version.)

(My setup: nodejs + typescript + twurple^8.1.4)