### PR TITLE
Add support for Device Code Flow authentication pattern

### DIFF
--- a/docs/auth/providers/refreshing.md
+++ b/docs/auth/providers/refreshing.md
@@ -57,10 +57,10 @@ If you already know the ID of the user you're adding, you can save a few interna
 authProvider.addUser('125328655', tokenData);
 ```
 
-## Getting the initial token using an OAuth code
+## Getting the initial token using the Authorization Code Grant Flow
 
-If you received an OAuth authorization code from Twitch's Authorization Code Flow,
-you can use that to directly get a suitable {@link AccessToken} object using the `exchangeToken` function:
+If you received an OAuth authorization code from Twitch's Authorization Code Grant Flow,
+you can use the `exchangeCode` function to get a suitable {@link AccessToken} object:
 
 ```ts twoslash
 // @module: esnext
@@ -75,3 +75,54 @@ const code = req.query.code; // get it from wherever
 const redirectUri = 'http://localhost'; // must match one of the URLs in the dev console exactly
 const tokenData = await exchangeCode(clientId, clientSecret, code, redirectUri);
 ```
+
+You can then add it to the provider:
+
+```ts
+await authProvider.addUserForToken(tokenData);
+```
+
+## Getting the initial token using Device Code Flow
+
+Device Code Flow is useful for apps where opening a redirect server is inconvenient, such as desktop apps,
+TV apps or command line tools.
+
+For apps running on open platforms like Windows, macOS or Linux, you should generally use Device Code Flow as a public
+client and avoid embedding a client secret in your application.
+
+Unlike the Authorization Code Grant Flow, Device Code Flow sends the requested scopes to Twitch's device endpoints
+instead of putting them in an authorization URL.
+Use the same scopes when starting the flow and when exchanging the device code.
+
+```ts twoslash
+// @module: esnext
+// @target: ES2017
+declare const clientId: string;
+// ---cut---
+import { startDeviceCodeFlow } from '@twurple/auth';
+
+const scopes = ['chat:read', 'chat:edit'];
+const deviceInfo = await startDeviceCodeFlow(clientId, scopes);
+
+console.log(`Go to ${deviceInfo.verificationUri} and enter ${deviceInfo.userCode}`);
+```
+
+After the user authorized your application, you can exchange the device code and add the resulting token to the provider:
+
+```ts twoslash
+// @module: esnext
+// @target: ES2017
+declare const clientId: string;
+declare const deviceInfo: { deviceCode: string };
+// ---cut---
+import { exchangeDeviceCode, RefreshingAuthProvider } from '@twurple/auth';
+
+const scopes = ['chat:read', 'chat:edit'];
+const authProvider = new RefreshingAuthProvider({ clientId });
+
+const tokenData = await exchangeDeviceCode(clientId, deviceInfo.deviceCode, scopes);
+await authProvider.addUserForToken(tokenData, ['chat']);
+```
+
+Public-client refresh tokens returned by Device Code Flow are one-time-use and expire after 30 days of inactivity.
+Always persist the newest token data from `onRefresh`, just like with other refreshing setups.

--- a/packages/auth/src/DeviceCode.external.ts
+++ b/packages/auth/src/DeviceCode.external.ts
@@ -1,0 +1,8 @@
+/** @internal */
+export interface DeviceCodeData {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	expires_in: number;
+	interval: number;
+}

--- a/packages/auth/src/DeviceCode.ts
+++ b/packages/auth/src/DeviceCode.ts
@@ -1,0 +1,29 @@
+/**
+ * The information necessary for a user to authorize an application using Device Code Flow.
+ */
+export interface DeviceCodeInfo {
+	/**
+	 * The device code, used to exchange for an access token once the user authorized.
+	 */
+	deviceCode: string;
+
+	/**
+	 * The code the user needs to enter on the verification page.
+	 */
+	userCode: string;
+
+	/**
+	 * The URI returned by Twitch where the user needs to authorize your application.
+	 */
+	verificationUri: string;
+
+	/**
+	 * The time, in seconds from obtainment, when the device code expires.
+	 */
+	expiresIn: number;
+
+	/**
+	 * The minimum time, in seconds, to wait between polling attempts.
+	 */
+	interval: number;
+}

--- a/packages/auth/src/helpers.external.ts
+++ b/packages/auth/src/helpers.external.ts
@@ -19,12 +19,30 @@ export function createGetAppTokenQuery(clientId: string, clientSecret: string) {
 }
 
 /** @internal */
-export function createRefreshTokenQuery(clientId: string, clientSecret: string, refreshToken: string) {
+export function createRefreshTokenQuery(clientId: string, clientSecret: string | undefined, refreshToken: string) {
 	return {
 		grant_type: 'refresh_token',
 		client_id: clientId,
 		client_secret: clientSecret,
 		refresh_token: refreshToken,
+	};
+}
+
+/** @internal */
+export function createDeviceCodeQuery(clientId: string, scopes: string[]) {
+	return {
+		client_id: clientId,
+		scopes: scopes.join(' '),
+	};
+}
+
+/** @internal */
+export function createExchangeDeviceCodeQuery(clientId: string, deviceCode: string, scopes: string[]) {
+	return {
+		grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+		client_id: clientId,
+		device_code: deviceCode,
+		scopes: scopes.join(' '),
 	};
 }
 

--- a/packages/auth/src/helpers.ts
+++ b/packages/auth/src/helpers.ts
@@ -2,9 +2,13 @@ import type { Logger } from '@d-fischer/logger';
 import { callTwitchApi, HttpStatusCodeError } from '@twurple/api-call';
 import type { AccessToken } from './AccessToken.js';
 import { type AccessTokenData } from './AccessToken.external.js';
+import type { DeviceCodeInfo } from './DeviceCode.js';
+import { type DeviceCodeData } from './DeviceCode.external.js';
 import { InvalidTokenError } from './errors/InvalidTokenError.js';
 import { InvalidTokenTypeError } from './errors/InvalidTokenTypeError.js';
 import {
+	createDeviceCodeQuery,
+	createExchangeDeviceCodeQuery,
 	createExchangeCodeQuery,
 	createGetAppTokenQuery,
 	createRefreshTokenQuery,
@@ -22,6 +26,17 @@ function createAccessTokenFromData(data: AccessTokenData): AccessToken {
 		scope: data.scope ?? [],
 		expiresIn: data.expires_in ?? null,
 		obtainmentTimestamp: Date.now(),
+	};
+}
+
+/** @internal */
+function createDeviceCodeInfoFromData(data: DeviceCodeData): DeviceCodeInfo {
+	return {
+		deviceCode: data.device_code,
+		userCode: data.user_code,
+		verificationUri: data.verification_uri,
+		expiresIn: data.expires_in,
+		interval: data.interval,
 	};
 }
 
@@ -52,6 +67,41 @@ export async function exchangeCode(
 }
 
 /**
+ * Starts the Device Code Flow.
+ *
+ * @param clientId The client ID of your application.
+ * @param scopes The scopes to request.
+ */
+export async function startDeviceCodeFlow(clientId: string, scopes: string[]): Promise<DeviceCodeInfo> {
+	return createDeviceCodeInfoFromData(
+		await callTwitchApi<DeviceCodeData>({
+			type: 'auth',
+			url: 'device',
+			method: 'POST',
+			query: createDeviceCodeQuery(clientId, scopes),
+		}),
+	);
+}
+
+/**
+ * Exchanges a device code for an access token.
+ *
+ * @param clientId The client ID of your application.
+ * @param deviceCode The device code returned by {@link startDeviceCodeFlow}.
+ * @param scopes The scopes requested when starting the Device Code Flow.
+ */
+export async function exchangeDeviceCode(clientId: string, deviceCode: string, scopes: string[]): Promise<AccessToken> {
+	return createAccessTokenFromData(
+		await callTwitchApi<AccessTokenData>({
+			type: 'auth',
+			url: 'token',
+			method: 'POST',
+			query: createExchangeDeviceCodeQuery(clientId, deviceCode, scopes),
+		}),
+	);
+}
+
+/**
  * Gets an app access token with your client credentials.
  *
  * @param clientId The client ID of your application.
@@ -69,15 +119,17 @@ export async function getAppToken(clientId: string, clientSecret: string): Promi
 }
 
 /**
- * Refreshes an expired access token with your client credentials and the refresh token that was given by the initial authentication.
+ * Refreshes an expired access token using a refresh token.
+ *
+ * Public clients using Device Code Flow do not need a client secret.
  *
  * @param clientId The client ID of your application.
- * @param clientSecret The client secret of your application.
+ * @param clientSecret The client secret, or `undefined` for public clients.
  * @param refreshToken The refresh token.
  */
 export async function refreshUserToken(
 	clientId: string,
-	clientSecret: string,
+	clientSecret: string | undefined,
 	refreshToken: string,
 ): Promise<AccessToken> {
 	return createAccessTokenFromData(

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,6 +7,7 @@ export type {
 export { accessTokenIsExpired, getExpiryDateOfAccessToken } from './AccessToken.js';
 
 export {
+	exchangeDeviceCode,
 	exchangeCode,
 	getAppToken,
 	getTokenInfo,
@@ -14,8 +15,10 @@ export {
 	getValidTokenFromProviderForIntent,
 	refreshUserToken,
 	revokeToken,
+	startDeviceCodeFlow,
 } from './helpers.js';
 
+export type { DeviceCodeInfo } from './DeviceCode.js';
 export { TokenFetcher } from './TokenFetcher.js';
 export { TokenInfo } from './TokenInfo.js';
 export type { TokenInfoData } from './TokenInfo.external.js';

--- a/packages/auth/src/providers/AppTokenAuthProvider.ts
+++ b/packages/auth/src/providers/AppTokenAuthProvider.ts
@@ -17,6 +17,11 @@ export class AppTokenAuthProvider implements AuthProvider {
 	private readonly _impliedScopes: string[];
 
 	/**
+	 * Whether the provider has access to a client secret.
+	 */
+	readonly hasClientSecret = true;
+
+	/**
 	 * Creates a new auth provider to receive an application token with using the client ID and secret.
 	 *
 	 * @param clientId The client ID of your application.

--- a/packages/auth/src/providers/AuthProvider.ts
+++ b/packages/auth/src/providers/AuthProvider.ts
@@ -20,6 +20,13 @@ export interface AuthProvider {
 	readonly clientId: string;
 
 	/**
+	 * Whether the provider has access to a client secret.
+	 *
+	 * This is optional for providers that can not determine this.
+	 */
+	readonly hasClientSecret?: boolean;
+
+	/**
 	 * The type of Authorization header to send. Defaults to "Bearer".
 	 */
 	readonly authorizationType?: string;

--- a/packages/auth/src/providers/RefreshingAuthProvider.ts
+++ b/packages/auth/src/providers/RefreshingAuthProvider.ts
@@ -7,6 +7,7 @@ import {
 	type AccessTokenMaybeWithUserId,
 	type AccessTokenWithUserId,
 } from '../AccessToken.js';
+import type { DeviceCodeInfo } from '../DeviceCode.js';
 import { CachedRefreshFailureError } from '../errors/CachedRefreshFailureError.js';
 import { IntermediateUserRemovalError } from '../errors/IntermediateUserRemovalError.js';
 import { InvalidTokenError } from '../errors/InvalidTokenError.js';
@@ -15,10 +16,12 @@ import { UnknownIntentError } from '../errors/UnknownIntentError.js';
 import {
 	compareScopeSets,
 	exchangeCode,
+	exchangeDeviceCode,
 	getAppToken,
 	getTokenInfo,
 	loadAndCompareTokenInfo,
 	refreshUserToken,
+	startDeviceCodeFlow,
 } from '../helpers.js';
 import { TokenFetcher } from '../TokenFetcher.js';
 import { type TokenInfo } from '../TokenInfo.js';
@@ -35,8 +38,10 @@ export interface RefreshingAuthProviderConfig {
 
 	/**
 	 * The client secret of your application.
+	 *
+	 * Only required if you use `addUserForCode` or app access tokens.
 	 */
-	clientSecret: string;
+	clientSecret?: string;
 
 	/**
 	 * A valid redirect URI for your application.
@@ -58,7 +63,7 @@ export interface RefreshingAuthProviderConfig {
 @rtfm<RefreshingAuthProvider>('auth', 'RefreshingAuthProvider', 'clientId')
 export class RefreshingAuthProvider extends EventEmitter implements AuthProvider {
 	private readonly _clientId: string;
-	/** @internal */ @Enumerable(false) private readonly _clientSecret: string;
+	/** @internal */ @Enumerable(false) private readonly _clientSecret?: string;
 	private readonly _redirectUri?: string;
 	/** @internal */ @Enumerable(false) private readonly _userAccessTokens = new Map<
 		string,
@@ -218,7 +223,33 @@ export class RefreshingAuthProvider extends EventEmitter implements AuthProvider
 		if (!this._redirectUri) {
 			throw new Error('This method requires you to pass a `redirectUri` as a configuration property');
 		}
-		const token = await exchangeCode(this._clientId, this._clientSecret, code, this._redirectUri);
+		const token = await exchangeCode(this._clientId, this._getClientSecretForCodeFlow(), code, this._redirectUri);
+
+		return await this.addUserForToken(token, intents);
+	}
+
+	/**
+	 * Starts the Device Code Flow.
+	 *
+	 * @param scopes The scopes to request.
+	 */
+	async startDeviceCodeFlow(scopes: string[]): Promise<DeviceCodeInfo> {
+		return await startDeviceCodeFlow(this._clientId, scopes);
+	}
+
+	/**
+	 * Gets an OAuth token from the given device code and adds the user to the provider.
+	 *
+	 * A device code can be obtained using the Device Code Flow.
+	 *
+	 * @param deviceCode The device code.
+	 * @param scopes The scopes requested when starting the Device Code Flow.
+	 * @param intents The intents to add to the user.
+	 *
+	 * Any intents that were already set before will be overwritten to point to the associated user instead.
+	 */
+	async addUserForDeviceCode(deviceCode: string, scopes: string[], intents?: string[]): Promise<string> {
+		const token = await exchangeDeviceCode(this._clientId, deviceCode, scopes);
 
 		return await this.addUserForToken(token, intents);
 	}
@@ -565,6 +596,22 @@ export class RefreshingAuthProvider extends EventEmitter implements AuthProvider
 	}
 
 	private async _refreshAppToken(): Promise<AccessToken> {
-		return (this._appAccessToken = await getAppToken(this._clientId, this._clientSecret));
+		return (this._appAccessToken = await getAppToken(this._clientId, this._getClientSecretForAppToken()));
+	}
+
+	private _getClientSecretForCodeFlow(): string {
+		if (!this._clientSecret) {
+			throw new Error('This method requires you to pass a `clientSecret` as a configuration property');
+		}
+
+		return this._clientSecret;
+	}
+
+	private _getClientSecretForAppToken(): string {
+		if (!this._clientSecret) {
+			throw new Error('App access tokens require you to pass a `clientSecret` as a configuration property');
+		}
+
+		return this._clientSecret;
 	}
 }

--- a/packages/auth/src/providers/RefreshingAuthProvider.ts
+++ b/packages/auth/src/providers/RefreshingAuthProvider.ts
@@ -223,7 +223,10 @@ export class RefreshingAuthProvider extends EventEmitter implements AuthProvider
 		if (!this._redirectUri) {
 			throw new Error('This method requires you to pass a `redirectUri` as a configuration property');
 		}
-		const token = await exchangeCode(this._clientId, this._getClientSecretForCodeFlow(), code, this._redirectUri);
+		if (!this._clientSecret) {
+			throw new Error('This method requires you to pass a `clientSecret` as a configuration property');
+		}
+		const token = await exchangeCode(this._clientId, this._clientSecret, code, this._redirectUri);
 
 		return await this.addUserForToken(token, intents);
 	}
@@ -392,6 +395,13 @@ export class RefreshingAuthProvider extends EventEmitter implements AuthProvider
 	 */
 	get clientId(): string {
 		return this._clientId;
+	}
+
+	/**
+	 * Whether the provider has access to a client secret.
+	 */
+	get hasClientSecret(): boolean {
+		return this._clientSecret !== undefined;
 	}
 
 	/**
@@ -596,22 +606,10 @@ export class RefreshingAuthProvider extends EventEmitter implements AuthProvider
 	}
 
 	private async _refreshAppToken(): Promise<AccessToken> {
-		return (this._appAccessToken = await getAppToken(this._clientId, this._getClientSecretForAppToken()));
-	}
-
-	private _getClientSecretForCodeFlow(): string {
-		if (!this._clientSecret) {
-			throw new Error('This method requires you to pass a `clientSecret` as a configuration property');
-		}
-
-		return this._clientSecret;
-	}
-
-	private _getClientSecretForAppToken(): string {
 		if (!this._clientSecret) {
 			throw new Error('App access tokens require you to pass a `clientSecret` as a configuration property');
 		}
 
-		return this._clientSecret;
+		return (this._appAccessToken = await getAppToken(this._clientId, this._clientSecret));
 	}
 }

--- a/packages/eventsub-http/src/EventSubHttpBase.ts
+++ b/packages/eventsub-http/src/EventSubHttpBase.ts
@@ -82,6 +82,9 @@ export abstract class EventSubHttpBase extends EventSubBase {
 		if (config.secret.length < 10 || config.secret.length > 100) {
 			throw new Error('Your secret must be between 10 and 100 characters long');
 		}
+		if (config.managed !== false && config.apiClient._authProvider.hasClientSecret === false) {
+			throw new Error('EventSub over HTTP requires an auth provider with a client secret');
+		}
 		super(config);
 		this._secret = config.secret;
 		this._strictHostCheck = config.strictHostCheck ?? true;


### PR DESCRIPTION
Type: Feature

Fixes: #590

This pull request adds support for Twitch's Device Code Grant Flow, allowing applications such as desktop, TV, and command-line apps to authenticate without a client secret or local redirect server.

It includes:

- `startDeviceCodeFlow` and `exchangeDeviceCode` helpers.
- A public `DeviceCodeInfo` type.
- Device Code Flow support in `RefreshingAuthProvider`.
- Support for public clients without a client secret.
- Device-code user registration through `addUserForDeviceCode`.
- Refresh-token handling for public-client tokens.
- Documentation and examples for starting and completing the flow, including token persistence guidance.

Authorization Code Grant Flow and app-token behavior remain unchanged.

This implements the functionality requested in [issue #590](https://github.com/twurple/twurple/issues/590).